### PR TITLE
Enable Studio

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -21,5 +21,7 @@
 include:
   - board: nice_nano_v2
     shield: kyria_rev3_left
+    snippet: studio-rpc-usb-uart
+    cmake-args: -DCONFIG_ZMK_STUDIO=y
   - board: nice_nano_v2
     shield: kyria_rev3_right


### PR DESCRIPTION
## Summary by Sourcery

Enable ZMK Studio support in the build configuration by adding the necessary snippet and CMake flag.

Build:
- Add 'studio-rpc-usb-uart' snippet to include ZMK Studio RPC over USB UART
- .cfg Set CONFIG_ZMK_STUDIO to y via CMake arguments for the Nice Nano V2 boards