### PR TITLE
Auto stash before merge of "retest" and "origin/retest"

### DIFF
--- a/config/kyria-layouts.dtsi
+++ b/config/kyria-layouts.dtsi
@@ -1,0 +1,137 @@
+#include <physical_layouts.dtsi>
+
+/ {
+    splitkb_kyria_6col_layout: splitkb_kyria_6col_layout {
+        compatible = "zmk,physical-layout";
+        display-name = "6 Column";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0   75       0     0     0>
+            , <&key_physical_attrs 100 100  100   75       0     0     0>
+            , <&key_physical_attrs 100 100  200   25       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100  400   25       0     0     0>
+            , <&key_physical_attrs 100 100  500   37       0     0     0>
+            , <&key_physical_attrs 100 100 1100   37       0     0     0>
+            , <&key_physical_attrs 100 100 1200   25       0     0     0>
+            , <&key_physical_attrs 100 100 1300    0       0     0     0>
+            , <&key_physical_attrs 100 100 1400   25       0     0     0>
+            , <&key_physical_attrs 100 100 1500   75       0     0     0>
+            , <&key_physical_attrs 100 100 1600   75       0     0     0>
+            , <&key_physical_attrs 100 100    0  175       0     0     0>
+            , <&key_physical_attrs 100 100  100  175       0     0     0>
+            , <&key_physical_attrs 100 100  200  125       0     0     0>
+            , <&key_physical_attrs 100 100  300  100       0     0     0>
+            , <&key_physical_attrs 100 100  400  125       0     0     0>
+            , <&key_physical_attrs 100 100  500  137       0     0     0>
+            , <&key_physical_attrs 100 100 1100  137       0     0     0>
+            , <&key_physical_attrs 100 100 1200  125       0     0     0>
+            , <&key_physical_attrs 100 100 1300  100       0     0     0>
+            , <&key_physical_attrs 100 100 1400  125       0     0     0>
+            , <&key_physical_attrs 100 100 1500  175       0     0     0>
+            , <&key_physical_attrs 100 100 1600  175       0     0     0>
+            , <&key_physical_attrs 100 100    0  275       0     0     0>
+            , <&key_physical_attrs 100 100  100  275       0     0     0>
+            , <&key_physical_attrs 100 100  200  225       0     0     0>
+            , <&key_physical_attrs 100 100  300  200       0     0     0>
+            , <&key_physical_attrs 100 100  400  225       0     0     0>
+            , <&key_physical_attrs 100 100  500  237       0     0     0>
+            , <&key_physical_attrs 100 100  350  225    3000   400   792>
+            , <&key_physical_attrs 100 100  350  225    4500   400   792>
+            , <&key_physical_attrs 100 100 1250  225 (-4500)  1300   792>
+            , <&key_physical_attrs 100 100 1250  225 (-3000)  1300   792>
+            , <&key_physical_attrs 100 100 1100  237       0     0     0>
+            , <&key_physical_attrs 100 100 1200  225       0     0     0>
+            , <&key_physical_attrs 100 100 1300  200       0     0     0>
+            , <&key_physical_attrs 100 100 1400  225       0     0     0>
+            , <&key_physical_attrs 100 100 1500  275       0     0     0>
+            , <&key_physical_attrs 100 100 1600  275       0     0     0>
+            , <&key_physical_attrs 100 100  250  325       0     0     0>
+            , <&key_physical_attrs 100 100  350  325       0     0     0>
+            , <&key_physical_attrs 100 100  350  325    1500   400   792>
+            , <&key_physical_attrs 100 100  350  325    3000   400   792>
+            , <&key_physical_attrs 100 100  350  325    4500   400   792>
+            , <&key_physical_attrs 100 100 1250  325 (-4500)  1300   792>
+            , <&key_physical_attrs 100 100 1250  325 (-3000)  1300   792>
+            , <&key_physical_attrs 100 100 1250  325 (-1500)  1300   792>
+            , <&key_physical_attrs 100 100 1250  325       0     0     0>
+            , <&key_physical_attrs 100 100 1350  325       0     0     0>
+            ;
+    };
+
+    splitkb_kyria_5col_layout: splitkb_kyria_5col_layout {
+        compatible = "zmk,physical-layout";
+        display-name = "5 Column";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0   75       0     0     0>
+            , <&key_physical_attrs 100 100  100   25       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300   25       0     0     0>
+            , <&key_physical_attrs 100 100  400   37       0     0     0>
+            , <&key_physical_attrs 100 100 1000   37       0     0     0>
+            , <&key_physical_attrs 100 100 1100   25       0     0     0>
+            , <&key_physical_attrs 100 100 1200    0       0     0     0>
+            , <&key_physical_attrs 100 100 1300   25       0     0     0>
+            , <&key_physical_attrs 100 100 1400   75       0     0     0>
+            , <&key_physical_attrs 100 100    0  175       0     0     0>
+            , <&key_physical_attrs 100 100  100  125       0     0     0>
+            , <&key_physical_attrs 100 100  200  100       0     0     0>
+            , <&key_physical_attrs 100 100  300  125       0     0     0>
+            , <&key_physical_attrs 100 100  400  137       0     0     0>
+            , <&key_physical_attrs 100 100 1000  137       0     0     0>
+            , <&key_physical_attrs 100 100 1100  125       0     0     0>
+            , <&key_physical_attrs 100 100 1200  100       0     0     0>
+            , <&key_physical_attrs 100 100 1300  125       0     0     0>
+            , <&key_physical_attrs 100 100 1400  175       0     0     0>
+            , <&key_physical_attrs 100 100    0  275       0     0     0>
+            , <&key_physical_attrs 100 100  100  225       0     0     0>
+            , <&key_physical_attrs 100 100  200  200       0     0     0>
+            , <&key_physical_attrs 100 100  300  225       0     0     0>
+            , <&key_physical_attrs 100 100  400  237       0     0     0>
+            , <&key_physical_attrs 100 100  250  225    3000   300   792>
+            , <&key_physical_attrs 100 100  250  225    4500   300   792>
+            , <&key_physical_attrs 100 100 1150  225 (-4500)  1200   792>
+            , <&key_physical_attrs 100 100 1150  225 (-3000)  1200   792>
+            , <&key_physical_attrs 100 100 1000  237       0     0     0>
+            , <&key_physical_attrs 100 100 1100  225       0     0     0>
+            , <&key_physical_attrs 100 100 1200  200       0     0     0>
+            , <&key_physical_attrs 100 100 1300  225       0     0     0>
+            , <&key_physical_attrs 100 100 1400  275       0     0     0>
+            , <&key_physical_attrs 100 100  150  325       0     0     0>
+            , <&key_physical_attrs 100 100  250  325       0     0     0>
+            , <&key_physical_attrs 100 100  250  325    1500   300   792>
+            , <&key_physical_attrs 100 100  250  325    3000   300   792>
+            , <&key_physical_attrs 100 100  250  325    4500   300   792>
+            , <&key_physical_attrs 100 100 1150  325 (-4500)  1200   792>
+            , <&key_physical_attrs 100 100 1150  325 (-3000)  1200   792>
+            , <&key_physical_attrs 100 100 1150  325 (-1500)  1200   792>
+            , <&key_physical_attrs 100 100 1150  325       0     0     0>
+            , <&key_physical_attrs 100 100 1250  325       0     0     0>
+            ;
+    };
+
+    splitkb_kyria_position_map {
+        compatible = "zmk,physical-layout-position-map";
+
+        complete;
+
+        twelve {
+            physical-layout = <&splitkb_kyria_6col_layout>;
+            positions
+                = < 0  1  2  3  4  5              6  7  8  9 10 11>
+                , <12 13 14 15 16 17             18 19 20 21 22 23>
+                , <24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39>
+                , <      40 41 42 43 44 45 46 47 48 49            >;
+        };
+
+        ten {
+            physical-layout = <&splitkb_kyria_5col_layout>;
+            positions
+                = <44  0  1  2  3  4              5  6  7  8  9 47>
+                , <45 10 11 12 13 14             15 16 17 18 19 48>
+                , <46 20 21 22 23 24 25 26 27 28 29 30 31 32 33 49>
+                , <      34 35 36 37 38 39 40 41 42 43            >;
+        };
+    };
+};

--- a/config/kyria_common.dtsi
+++ b/config/kyria_common.dtsi
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/matrix_transform.h>
+
+#include "kyria-layouts.dtsi"
+
+/ {
+    chosen {
+        zephyr,display = &oled;
+        zmk,kscan = &kscan0;
+        zmk,physical-layout = &splitkb_kyria_6col_layout;
+    };
+
+    kscan0: kscan {
+        compatible = "zmk,kscan-gpio-matrix";
+        wakeup-source;
+
+        diode-direction = "col2row";
+    };
+
+    left_encoder: encoder_left {
+        compatible = "alps,ec11";
+        steps = <80>;
+        status = "disabled";
+    };
+
+    right_encoder: encoder_right {
+        compatible = "alps,ec11";
+        steps = <80>;
+        status = "disabled";
+    };
+
+    sensors: sensors {
+        compatible = "zmk,keymap-sensors";
+        sensors = <&left_encoder &right_encoder>;
+        triggers-per-rotation = <20>;
+    };
+
+    // TODO: RGB node(s)
+};
+
+&pro_micro_i2c {
+    status = "okay";
+
+    oled: ssd1306@3c {
+        compatible = "solomon,ssd1306fb";
+        reg = <0x3c>;
+        width = <128>;
+        height = <64>;
+        segment-offset = <0>;
+        page-offset = <0>;
+        display-offset = <0>;
+        multiplex-ratio = <63>;
+        prechargep = <0x22>;
+        inversion-on;
+    };
+};

--- a/config/kyria_rev3.dtsi
+++ b/config/kyria_rev3.dtsi
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "kyria_common.dtsi"
+
+&splitkb_kyria_6col_layout {
+    transform = <&default_transform>;
+};
+
+&splitkb_kyria_5col_layout {
+    status = "disabled";
+};
+
+/ {
+    default_transform: keymap_transform_0 {
+        compatible = "zmk,matrix-transform";
+        columns = <14>;
+        rows = <4>;
+        // | MX6  | MX5  | MX4  | MX3  | MX2  | MX1  |                               | MX1  | MX2  | MX3  | MX4  | MX5  | MX6  |
+        // | MX12 | MX11 | MX10 | MX9  | MX8  | MX7  |                               | MX7  | MX8  | MX9  | MX10 | MX11 | MX12 |
+        // | MX20 | MX19 | MX18 | MX17 | MX16 | MX15 | MX14 | MX13 |   | MX13 | MX14 | MX15 | MX16 | MX17 | MX18 | MX19 | MX20 |
+        //                    | MX25 | MX24 | MX23 | MX22 | MX21 |       | MX21 | MX22 | MX23 | MX24 | MX25 |
+        map = <
+        RC(0,0) RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5)                                  RC(0,8) RC(0,9) RC(0,10) RC(0,11) RC(0,12) RC(0,13)
+        RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5)                                  RC(1,8) RC(1,9) RC(1,10) RC(1,11) RC(1,12) RC(1,13)
+        RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5) RC(3,3) RC(2,6) RC(2,7) RC(3,10) RC(2,8) RC(2,9) RC(2,10) RC(2,11) RC(2,12) RC(2,13)
+        RC(3,2) RC(3,4) RC(3,5) RC(3,1) RC(3,6) RC(3,7) RC(3,12) RC(3,8) RC(3,9) RC(3,11)
+        >;
+    };
+};
+
+&left_encoder {
+    a-gpios = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+    b-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+};
+
+&right_encoder {
+    a-gpios = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+    b-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+};

--- a/config/kyria_rev3.keymap
+++ b/config/kyria_rev3.keymap
@@ -22,6 +22,16 @@
 
 &caps_word { continue-list = <UNDERSCORE MINUS>; };
 
+&sensors {
+    compatible = "zmk,keymap-sensors";
+    sensors = <&right_encoder>;
+    triggers-per-rotation = <20>;
+};
+
+&right_encoder {
+    status = "okay";
+};
+
 / {
     keymap {
         compatible = "zmk,keymap";
@@ -35,11 +45,11 @@
             bindings = <
             &kp ESC   &kp Q &kp W &kp E &kp R &kp T                                                  &kp Y &kp U  &kp I     &kp O   &kp P    &kp BSLH
             &kp TAB   &kp A &kp S &kp D &kp F &kp G                                                  &kp H &kp J  &kp K     &kp L   &kp SEMI &kp SQT
-            &kp LSHFT &kp Z &kp X &kp C &kp V &kp B &kp LSHFT &kp LSHFT            &mo 1   &kp LSHFT &kp N &kp M  &kp COMMA &kp DOT &kp FSLH &mo 1
+            &kp LSHFT &kp Z &kp X &kp C &kp V &kp B &kp LSHFT &kp LSHFT            &none   &kp LSHFT &kp N &kp M  &kp COMMA &kp DOT &kp FSLH &mo 1
                                   &kp LGUI &kp DEL &kp RET &kp SPACE &kp ESC       &kp RET &kp SPACE &kp TAB &kp BSPC &kp RALT
             >;
 
-            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
+            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp C_VOL_UP C_VOL_DN>;
         };
         function_layer {
             // ---------------------------------------------------------------------------------------------------------------------------------
@@ -50,7 +60,7 @@
             bindings = <
             &studio_unlock &trans &bt BT_CLR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2              &trans &trans &trans &trans &trans &trans
             &trans &trans &trans     &bt BT_SEL 3 &bt BT_SEL 4 &trans                    &trans &trans &trans &trans &trans &trans
-            &trans &trans &trans &trans &trans &trans &trans &trans        &trans &trans &trans &trans &trans &trans &trans &trans
+            &trans &trans &trans &trans &trans &trans &trans &trans        &none &trans &trans &trans &trans &trans &trans &trans
                                  &trans &trans &trans &trans &trans        &trans &trans &trans &trans &trans
             >;
 
@@ -58,3 +68,4 @@
         };
     };
 };
+

--- a/config/kyria_rev3.zmk.yml
+++ b/config/kyria_rev3.zmk.yml
@@ -1,0 +1,16 @@
+file_format: "1"
+id: kyria_rev3
+name: Kyria Rev3
+type: shield
+url: https://splitkb.com/products/kyria-pcb-kit
+requires: [pro_micro]
+exposes: [i2c_oled]
+features:
+  - keys
+  - display
+  - encoder
+  - underglow
+  - studio
+siblings:
+  - kyria_rev3_left
+  - kyria_rev3_right

--- a/config/kyria_rev3_left.overlay
+++ b/config/kyria_rev3_left.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "kyria_rev3.dtsi"
+
+&kscan0 {
+    row-gpios
+    = <&pro_micro 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+    , <&pro_micro 5 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+    , <&pro_micro 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+    , <&pro_micro 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+    ;
+    col-gpios
+    = <&pro_micro 10 GPIO_ACTIVE_HIGH>
+    , <&pro_micro 16 GPIO_ACTIVE_HIGH>
+    , <&pro_micro 14 GPIO_ACTIVE_HIGH>
+    , <&pro_micro 15 GPIO_ACTIVE_HIGH>
+    , <&pro_micro 18 GPIO_ACTIVE_HIGH>
+    , <&pro_micro 19 GPIO_ACTIVE_HIGH>
+    , <&pro_micro 8 GPIO_ACTIVE_HIGH>
+    ;
+};
+
+&left_encoder {
+    status = "okay";
+};

--- a/config/kyria_rev3_right.overlay
+++ b/config/kyria_rev3_right.overlay
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "kyria_rev3.dtsi"
+
+&default_transform {
+    col-offset = <7>;
+};
+
+&kscan0 {
+    row-gpios
+    = <&pro_micro 19 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+    , <&pro_micro 18 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+    , <&pro_micro 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+    , <&pro_micro 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+    ;
+    col-gpios
+    = <&pro_micro 16 GPIO_ACTIVE_HIGH>
+    , <&pro_micro 4  GPIO_ACTIVE_HIGH>
+    , <&pro_micro 5  GPIO_ACTIVE_HIGH>
+    , <&pro_micro 6  GPIO_ACTIVE_HIGH>
+    , <&pro_micro 7  GPIO_ACTIVE_HIGH>
+    , <&pro_micro 8  GPIO_ACTIVE_HIGH>
+    , <&pro_micro 10 GPIO_ACTIVE_HIGH>
+    ;
+};
+
+&right_encoder {
+    status = "okay";
+};


### PR DESCRIPTION
## Summary by Sourcery

Add initial ZMK support for the Kyria Rev3 keyboard shield by introducing a new keymap YAML and associated device tree overlays

New Features:
- Add kyria_rev3.zmk.yml to define the Rev3 shield configuration
- Add kyria_common.dtsi, kyria_rev3.dtsi and layout overlays for left and right halves

Chores:
- Remove deprecated config/kyria_rev3.keymap file